### PR TITLE
remove problematic version

### DIFF
--- a/source.json
+++ b/source.json
@@ -22,8 +22,7 @@
             "id":"com.llealloo.audiolink",
             "releases":[
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/0.3.2/com.llealloo.audiolink-0.3.2.zip",
-                "https://github.com/llealloo/vrc-udon-audio-link/releases/download/0.3.1/com.llealloo.audiolink-0.3.1.zip",
-                "https://github.com/llealloo/vrc-udon-audio-link/releases/download/0.3.0/com.llealloo.audiolink-0.3.0.zip"
+                "https://github.com/llealloo/vrc-udon-audio-link/releases/download/0.3.1/com.llealloo.audiolink-0.3.1.zip"
             ]
         },
         {


### PR DESCRIPTION
we would like to remove 0.3.0 because it pulls in the world sdk and udonsharp and bricks avatar projects