### PR TITLE
Added Avatars 3.0 Manager 2.0.24

### DIFF
--- a/source.json
+++ b/source.json
@@ -40,6 +40,7 @@
         {
             "id":"dev.vrlabs.av3manager",
             "releases":[
+                    "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.24/Avatars_3.0_Manager_2.0.24.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.23/Avatars_3.0_Manager_2.0.23.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.20/Avatars_3.0_Manager_2.0.20.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.19/Avatars_3.0_Manager_2.0.19.zip",


### PR DESCRIPTION
This version adds official support to the 3.3.x family of sdk versions (specifically support for avatar sdk >=3.2.0 < 3.4.0).

There were no breaking changes for us with the 3.3.0 update, so the only real change here is the dependency support in the package.json

(https://github.com/VRLabs/Avatars-3.0-Manager/pull/21)