### PR TITLE
AudioLink 1.2.0

### DIFF
--- a/source.json
+++ b/source.json
@@ -21,6 +21,7 @@
         {
             "id":"com.llealloo.audiolink",
             "releases":[
+                "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.2.0/com.llealloo.audiolink-1.2.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.1.0/com.llealloo.audiolink-1.1.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.0.0/com.llealloo.audiolink-1.0.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/0.3.2/com.llealloo.audiolink-0.3.2.zip",


### PR DESCRIPTION
Apologies for the unfortunate release cadence here. We have another fix:

## 1.2.0 - October 9th, 2023
### Changes
- **Important for shader developers:** Deprecated AudioLinkGetVersion() and replaced it with AudioLinkGetVersionMajor() and AudioLinkGetVersionMinor(). For this current release, both will return 1.0f. Unfortunately, the recent 1.0.0 and 1.1.0 versions will be detected as 0 on the major version due to an oversight. These should be the only versions in existence with an incorrect version number. For all other versions, these 2 functions are backwards compatible. Any shaders going forward should use these 2 functions, or read directly from green (major version) and alpha (minor version) of the pixel at `ALPASS_GENERALVU`.