### PR TITLE
Update av3 emulator to 3.2.4

### DIFF
--- a/source.json
+++ b/source.json
@@ -69,7 +69,8 @@
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.0/lyuma.av3emulator-3.2.0.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.1/lyuma.av3emulator-3.2.1.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.2/lyuma.av3emulator-3.2.2.zip",
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.3/lyuma.av3emulator-3.2.3.zip"
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.3/lyuma.av3emulator-3.2.3.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.4/lyuma.av3emulator-3.2.4.zip"
             ]
         }
     ]


### PR DESCRIPTION
Fixes cannot be installed due to a bug in VCC. Removes localPath. See vrchat-community/creator-companion#368