### PR TITLE
Updated Avatars 3.0 Manager to v2.0.26

### DIFF
--- a/source.json
+++ b/source.json
@@ -43,6 +43,7 @@
         {
             "id":"dev.vrlabs.av3manager",
             "releases":[
+                    "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.26/Avatars_3.0_Manager_2.0.26.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.25/Avatars_3.0_Manager_2.0.25.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.24/Avatars_3.0_Manager_2.0.24.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.23/Avatars_3.0_Manager_2.0.23.zip",


### PR DESCRIPTION
This version adds official support to the 3.5.x family of sdk versions, and updates the internal list of default parameters with some of the ones added recently (we still haven't added new friend parameter, will do it at a later time once we sorted some things out)
