### PR TITLE
AudioLink 1.2.1

### DIFF
--- a/source.json
+++ b/source.json
@@ -21,6 +21,7 @@
         {
             "id":"com.llealloo.audiolink",
             "releases":[
+                "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.2.1/com.llealloo.audiolink-1.2.1.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.2.0/com.llealloo.audiolink-1.2.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.1.0/com.llealloo.audiolink-1.1.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.0.0/com.llealloo.audiolink-1.0.0.zip",


### PR DESCRIPTION
This release brings some fixes and tweaks for Unity 2022.3

## 1.2.1 - December 9th, 2023
### Changes
- Enabled Async GPU readbacks on mobile platforms, including Quest. This let's you access data via Udon much more cheaply. To facilitate this, AudioLink now requires Unity 2022.3 or newer. (pema)
- Moved the AudioLink menu in the top menu bar into the "Tools" submenu, to bring it in line with other similar packages. (techanon)
- Updated the "Add AudioLink Prefab to Scene" button to check for the existence of a prefab before adding a new one. (techanon)
- Made the controller call `AudioLink.AudioLinkEnable` and `AudioLink.AudioLinkDisable` instead of toggling the AudioLink GameObject. (Nestorboy)

### Bugfixes
- Fixed normals being incorrectly flipped on the logo of the AudioLink controller. (llealloo)
- Fixed a bug where shader ID's used by AudioLink weren't properly initialized in some cases. (Nestorboy)
- Updated the shader used for the AudioLink controller logo to support single pass stereo instanced rendering. (Nestorboy)
- Fix an issue where shader ID's were initialized too late when AudioLink API was used too early in the script execution cycle. (pema)
