### PR TITLE
Upgrade avatar manager to 2.0.27

### DIFF
--- a/source.json
+++ b/source.json
@@ -44,6 +44,7 @@
         {
             "id":"dev.vrlabs.av3manager",
             "releases":[
+                    "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.27/Avatars_3.0_Manager_2.0.27.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.26/Avatars_3.0_Manager_2.0.26.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.25/Avatars_3.0_Manager_2.0.25.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.24/Avatars_3.0_Manager_2.0.24.zip",


### PR DESCRIPTION
- Added proper copying of the Normalize Blend Values field
- Fixed ClipSwapItem error when starting new project with av3 manager present
- Added IsOnFriendsList and AvatarVersion parameters
- Removed Japanese readme
- Fixed name in license