### PR TITLE
AudioLink 1.3.0

### DIFF
--- a/source.json
+++ b/source.json
@@ -21,6 +21,7 @@
         {
             "id":"com.llealloo.audiolink",
             "releases":[
+                "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.3.0/com.llealloo.audiolink-1.3.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.2.1/com.llealloo.audiolink-1.2.1.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.2.0/com.llealloo.audiolink-1.2.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.1.0/com.llealloo.audiolink-1.1.0.zip",


### PR DESCRIPTION
Pretty much just bugfixes

## 1.3.0 - February 18th, 2024
### Changes
- Deprecated various static properties in AudioLink.DataAPI in favor of static functions to work around a miscompilation bug in UdonSharp.
- Deprecated the underused "AudioLink extra packages", which contains a single "AudioLinkZone" script. The script is now in the main package.

### Bugfixes
- Fixed an issue where an exception would be thrown when leaving a world with AudioLink enabled. (@ShingenPizza)
- Fixed a bug where theme colors would reset when someone joins the instance. (Teeh, orels1, pema)
