### PR TITLE
lyuma.av3emulator 3.3.1

### DIFF
--- a/source.json
+++ b/source.json
@@ -77,7 +77,8 @@
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.2/lyuma.av3emulator-3.2.2.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.3/lyuma.av3emulator-3.2.3.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.4/lyuma.av3emulator-3.2.4.zip",
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.3.0/lyuma.av3emulator-3.3.0.zip"
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.3.0/lyuma.av3emulator-3.3.0.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.3.1/lyuma.av3emulator-3.3.1.zip"
             ]
         }
     ]


### PR DESCRIPTION
Updates av3emulator to version 3.3.1 which fixes some initialization order bugs related to VRCFury, NDMF and other build frameworks