### PR TITLE
Update VRWorld Toolkit to V3.0.0

### DIFF
--- a/source.json
+++ b/source.json
@@ -33,7 +33,7 @@
         {
             "id":"dev.onevr.vrworldtoolkit",
             "releases":[
-                "https://github.com/oneVR/VRWorldToolkit/releases/download/V3.0.0/VRWorldToolkit_VCC_V3.0.0.zip",
+                "https://github.com/oneVR/VRWorldToolkit/releases/download/V3.0.1/VRWorldToolkit_V3.0.1.zip",
                 "https://github.com/oneVR/VRWorldToolkit/releases/download/V2.1.5/VRWorldToolkit_VCC_V2.1.5.zip"
             ]
         },


### PR DESCRIPTION
Patch notes can be found here:

https://github.com/oneVR/VRWorldToolkit/releases/tag/V3.0.0