### PR TITLE
Release av3emulator 3.4.0, and sort in descending order.

### DIFF
--- a/source.json
+++ b/source.json
@@ -73,14 +73,15 @@
         {
             "id":"lyuma.av3emulator",
             "releases":[
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.1.3/lyuma.av3emulator-3.1.3.zip",
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.0/lyuma.av3emulator-3.2.0.zip",
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.1/lyuma.av3emulator-3.2.1.zip",
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.2/lyuma.av3emulator-3.2.2.zip",
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.3/lyuma.av3emulator-3.2.3.zip",
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.4/lyuma.av3emulator-3.2.4.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.4.0/lyuma.av3emulator-3.4.0.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.3.1/lyuma.av3emulator-3.3.1.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.3.0/lyuma.av3emulator-3.3.0.zip",
-                "https://github.com/lyuma/Av3Emulator/releases/download/v3.3.1/lyuma.av3emulator-3.3.1.zip"
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.4/lyuma.av3emulator-3.2.4.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.3/lyuma.av3emulator-3.2.3.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.2/lyuma.av3emulator-3.2.2.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.1/lyuma.av3emulator-3.2.1.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.2.0/lyuma.av3emulator-3.2.0.zip",
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.1.3/lyuma.av3emulator-3.1.3.zip"
             ]
         }
     ]


### PR DESCRIPTION
Updated to descending sort order to match other packages.

3.4.0 comes with a new inspector written by Dreadrith as well as support for the new VRCHeadChop component and the VRCAnimatorPlayAudio state machine behaviour.