### PR TITLE
Update av3 manager to 2.0.31

### DIFF
--- a/source.json
+++ b/source.json
@@ -50,6 +50,7 @@
         {
             "id":"dev.vrlabs.av3manager",
             "releases":[
+                    "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.31/dev.vrlabs.av3manager-2.0.31.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.30/dev.vrlabs.av3manager-2.0.30.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.29/dev.vrlabs.av3manager-2.0.29.zip",
                     "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/2.0.28/dev.vrlabs.av3manager-2.0.28.zip",


### PR DESCRIPTION
This fixes vrchat 2019 support for the avatar 3.0 manager