### PR TITLE
Av3Emulator v3.4.4

### DIFF
--- a/source.json
+++ b/source.json
@@ -81,6 +81,7 @@
         {
             "id":"lyuma.av3emulator",
             "releases":[
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.4.4/lyuma.av3emulator-3.4.4.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.4.3/lyuma.av3emulator-3.4.3.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.4.0/lyuma.av3emulator-3.4.0.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.3.1/lyuma.av3emulator-3.3.1.zip",


### PR DESCRIPTION
Update Av3Emulator.
Changing to remove upper bound for VRCSDK since it's causing VPM to downgrade the SDK to 3.6.0-beta1 and that's been a big source of confusion for users, and usually VRCSDK doesn't break compatibility.