### PR TITLE
AudioLink 2.0.0

### DIFF
--- a/source.json
+++ b/source.json
@@ -21,6 +21,7 @@
         {
             "id":"com.llealloo.audiolink",
             "releases":[
+                "https://github.com/llealloo/audiolink/releases/download/2.0.0/com.llealloo.audiolink-2.0.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.4.0/com.llealloo.audiolink-1.4.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.3.0/com.llealloo.audiolink-1.3.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.2.1/com.llealloo.audiolink-1.2.1.zip",


### PR DESCRIPTION
Small set of improvements. Bumping major version due to 1 breaking API change.

## 2.0.0 - September 8th, 2024
### New features
- Added the ability to adjust how the AudioLink controller is synced. You can sync every part of it, none of it, or everything except the gain and power controls. (fundale)
- Added support for dual mono audio sources, for cases where you want to supply the left and right channel from separate sources. (fundale)
- Added a utility script for driving blend shapes with AudioLink - AudioReactiveBlendshapes. Just add the script to a GameObject that has a SkinnedMeshRenderer to use. (fundale)
- Added rudimentary support for using AudioLink with the WebGL build target. (fundale, hill)

### Changes
- Lowered the default volume for the AudioLink avatar prefab a bit. (pema)
- Reduces the network traffic incurred by syncing AudioLink state a bit. (Happyrobot33)
- Deprecated `ThemeColorController.customThemeColors` as the behavior has changed. Please use `ThemeColorController.SetCustomThemeColors` and `ThemeColorController.GetCustomThemeColors` instead. This is a (minor) breaking change.

### Bugfixes
- Fixed a bug where the color chord theme color toggle on the controller wasn't properly synced. (pema)

