### PR TITLE
AudioLink 2.1.0

### DIFF
--- a/source.json
+++ b/source.json
@@ -21,6 +21,7 @@
         {
             "id":"com.llealloo.audiolink",
             "releases":[
+                "https://github.com/llealloo/audiolink/releases/download/2.1.0/com.llealloo.audiolink-2.1.0.zip",
                 "https://github.com/llealloo/audiolink/releases/download/2.0.0/com.llealloo.audiolink-2.0.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.4.0/com.llealloo.audiolink-1.4.0.zip",
                 "https://github.com/llealloo/vrc-udon-audio-link/releases/download/1.3.0/com.llealloo.audiolink-1.3.0.zip",


### PR DESCRIPTION
## 2.1.0 - March 10th, 2025
### New features
- Added support for getting phase information from AudioLink, via the alpha channel of the `ALPASS_DFT` section. There is an example shader using this feature included at `com.llealloo.audiolink/Runtime/Shaders/AudioLinkDocs_Demo10.shader`. (tt0fu)

### Changes
- Made some optimizations to handling of global strings. Should result in less allocations. (techanon)
- Changed default resolution used for AudioLinkAvatar prefab to 360p.

### Bugfixes
- Fixed some issues preventing the use of AudioLink on Unity 6.x. (techanon, float3)

