### PR TITLE
Update VRWorld Toolkit to V3.4.1

### DIFF
--- a/source.json
+++ b/source.json
@@ -39,6 +39,7 @@
         {
             "id":"dev.onevr.vrworldtoolkit",
             "releases":[
+                "https://github.com/oneVR/VRWorldToolkit/releases/download/V3.4.1/VRWorldToolkit_V3.4.1.zip",
                 "https://github.com/oneVR/VRWorldToolkit/releases/download/V3.4.0/VRWorldToolkit_V3.4.0.zip",
                 "https://github.com/oneVR/VRWorldToolkit/releases/download/V3.3.2/VRWorldToolkit_V3.3.2.zip",
                 "https://github.com/oneVR/VRWorldToolkit/releases/download/V3.3.1/VRWorldToolkit_V3.3.1.zip",


### PR DESCRIPTION
Patch notes can be found here: https://github.com/oneVR/VRWorldToolkit/releases/tag/V3.4.1

Thank you!