### PR TITLE
Add release link for Av3Emulator v3.4.13

### DIFF
--- a/source.json
+++ b/source.json
@@ -108,6 +108,7 @@
         {
             "id":"lyuma.av3emulator",
             "releases":[
+                "https://github.com/lyuma/Av3Emulator/releases/download/v3.4.13/lyuma.av3emulator-3.4.13.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.4.10/lyuma.av3emulator-3.4.10.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.4.9/lyuma.av3emulator-3.4.9.zip",
                 "https://github.com/lyuma/Av3Emulator/releases/download/v3.4.8/lyuma.av3emulator-3.4.8.zip",


### PR DESCRIPTION
Released version 3.4.13 of Av3Emulator.

What happened to 3.4.11 and 3.4.12, you ask? Sshhhh, nobody needs to know.