### PR TITLE
Update Fluent UI Web Components version to 2.6.1

### DIFF
--- a/Website/app.js
+++ b/Website/app.js
@@ -1,4 +1,4 @@
-import { baseLayerLuminance, StandardLuminance } from 'https://unpkg.com/@fluentui/web-components';
+import { baseLayerLuminance, StandardLuminance } from 'https://unpkg.com/@fluentui/web-components@2.6.1';
 
 const LISTING_URL = "{{ listingInfo.Url }}";
 

--- a/Website/index.html
+++ b/Website/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>VCC Listing</title>
-  <script type="module" src="https://unpkg.com/@fluentui/web-components"></script>
+  <script type="module" src="https://unpkg.com/@fluentui/web-components@2.6.1"></script>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>


### PR DESCRIPTION
Both Website/app.js and Website/index.html imported @fluentui/web-components from unpkg without a version pin. That means the CDN always served whatever the latest tag pointed at.

For ~2 years that was effectively 2.6.1, so nothing moved. Two days ago 3.0.0 was published — which is a breaking, incompatible release — and the unpinned import silently pulled it in, breaking the site.